### PR TITLE
Make audiences nullable in Oauth2JwtAccessTokenValidator

### DIFF
--- a/fastapi_security/oauth2.py
+++ b/fastapi_security/oauth2.py
@@ -56,6 +56,8 @@ class Oauth2JwtAccessTokenValidator:
                 Accepted `aud` values for incoming access tokens. Could be a list of string, a string or None.
             jwks_cache_period:
                 How many seconds to cache the JWKS response. Defaults to 1 hour.
+            decode_options:
+                Other options for PyJWT's decode function.
         """
         if aiohttp is None:
             raise MissingDependency(

--- a/fastapi_security/oauth2.py
+++ b/fastapi_security/oauth2.py
@@ -41,7 +41,7 @@ class Oauth2JwtAccessTokenValidator:
     def init(
         self,
         jwks_url: str,
-        audiences: Iterable[str],
+        audiences: Optional[Union[str, Iterable[str]]],
         *,
         jwks_cache_period: int = DEFAULT_JWKS_RESPONSE_CACHE_PERIOD,
     ):
@@ -52,7 +52,7 @@ class Oauth2JwtAccessTokenValidator:
                 The JWKS endpoint to fetch the public keys from. Usually in the
                 format: "https://domain/.well-known/jwks.json"
             audiences:
-                Accepted `aud` values for incoming access tokens
+                Accepted `aud` values for incoming access tokens. Could be a list of string, a string or None.
             jwks_cache_period:
                 How many seconds to cache the JWKS response. Defaults to 1 hour.
         """
@@ -66,7 +66,7 @@ class Oauth2JwtAccessTokenValidator:
             )
         self._jwks_url = jwks_url
         self._jwks_cache_period = float(jwks_cache_period)
-        self._audiences = list(audiences)
+        self._audiences = audiences
 
     def is_configured(self) -> bool:
         return bool(self._jwks_url)

--- a/fastapi_security/oauth2.py
+++ b/fastapi_security/oauth2.py
@@ -44,6 +44,7 @@ class Oauth2JwtAccessTokenValidator:
         audiences: Optional[Union[str, Iterable[str]]],
         *,
         jwks_cache_period: int = DEFAULT_JWKS_RESPONSE_CACHE_PERIOD,
+        decode_options: dict = None
     ):
         """Set up Oauth 2.0 JWT validation
 
@@ -67,6 +68,7 @@ class Oauth2JwtAccessTokenValidator:
         self._jwks_url = jwks_url
         self._jwks_cache_period = float(jwks_cache_period)
         self._audiences = audiences
+        self._decode_options = decode_options
 
     def is_configured(self) -> bool:
         return bool(self._jwks_url)
@@ -161,4 +163,4 @@ class Oauth2JwtAccessTokenValidator:
         self, public_key: _RSAPublicKey, access_token: str
     ) -> Dict[str, Any]:
         # NOTE: jwt.decode has erroneously set key: str
-        return jwt.decode(access_token, key=public_key, audience=self._audiences, algorithms=["RS256"])  # type: ignore
+        return jwt.decode(access_token, key=public_key, audience=self._audiences, algorithms=["RS256"], **self._decode_options)  # type: ignore


### PR DESCRIPTION
Sometimes it's not required to check for aud.
Previously, this library didn't allow that, requiring a list of audiences to check the JWT token against.
A simple change of logic allows now allows doing so.